### PR TITLE
DEVI-3204: Trying to unlock only if the lock is already held

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ buildscript {
 			name "jboss-snapshots"
 			url "http://snapshots.jboss.org/maven2/"
 		}
+		maven {
+			url "https://plugins.gradle.org/m2/"
+		}
 	}
 	dependencies {
 		classpath 'org.hibernate.build.gradle:gradle-maven-publish-auth:2.0.1'
@@ -31,6 +34,7 @@ buildscript {
 		classpath 'org.hibernate.build.gradle:version-injection-plugin:1.0.0'
 		classpath 'org.hibernate.build.gradle:gradle-xjc-plugin:1.0.2.Final'
 		classpath 'com.github.lburgazzoli:lb-karaf-features-gen:1.0.0-SNAPSHOT'
+		classpath "gradle.plugin.com.palantir.gradle.gitversion:gradle-git-version:0.12.0-rc2"
 	}
 }
 
@@ -104,6 +108,7 @@ subprojects { subProject ->
 	apply plugin: 'checkstyle'
 	apply plugin: 'build-dashboard'
 	apply plugin: 'project-report'
+	apply plugin: 'com.palantir.git-version'
 
 	apply plugin: org.hibernate.build.HibernateBuildPlugin
 

--- a/hibernate-ehcache/hibernate-ehcache.gradle
+++ b/hibernate-ehcache/hibernate-ehcache.gradle
@@ -4,6 +4,9 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
+
+version='5.1.0.Final.Fuga'
+
 dependencies {
     compile project( ':hibernate-core' )
     compile( libraries.ehcache )

--- a/hibernate-ehcache/hibernate-ehcache.gradle
+++ b/hibernate-ehcache/hibernate-ehcache.gradle
@@ -5,7 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 
-version='5.1.0.Final.Fuga'
+version="${version}-Fuga-${versionDetails().gitHash}"
 
 dependencies {
     compile project( ':hibernate-core' )

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/regions/EhcacheTransactionalDataRegion.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/regions/EhcacheTransactionalDataRegion.java
@@ -13,6 +13,7 @@ import net.sf.ehcache.Element;
 import net.sf.ehcache.concurrent.CacheLockProvider;
 import net.sf.ehcache.concurrent.LockType;
 import net.sf.ehcache.concurrent.StripedReadWriteLockSync;
+import net.sf.ehcache.concurrent.Sync;
 import net.sf.ehcache.constructs.nonstop.NonStopCacheException;
 
 import org.hibernate.boot.spi.SessionFactoryOptions;
@@ -224,7 +225,10 @@ public class EhcacheTransactionalDataRegion extends EhcacheDataRegion implements
 	 */
 	public final void writeUnlock(Object key) throws CacheException {
 		try {
-			lockProvider.getSyncForKey( key ).unlock( LockType.WRITE );
+			Sync sync = lockProvider.getSyncForKey( key );
+			if ( sync.isHeldByCurrentThread( LockType.WRITE ) ) {
+				sync.unlock( LockType.WRITE );
+			}
 		}
 		catch (net.sf.ehcache.CacheException e) {
 			if ( e instanceof NonStopCacheException ) {


### PR DESCRIPTION
Based on http://forums.terracotta.org/forums/posts/list/8361.page
```
java.lang.IllegalMonitorStateException
	at com.tc.object.locks.ClientLockImpl.release(ClientLockImpl.java:811)
	at com.tc.object.locks.ClientLockImpl.unlock(ClientLockImpl.java:173)
	at com.tc.object.locks.ClientLockManagerImpl.unlock(ClientLockManagerImpl.java:225)
	at com.tc.platform.PlatformServiceImpl$2.call(PlatformServiceImpl.java:617)
	at com.tc.object.tx.ClientTransactionManagerImpl.call(ClientTransactionManagerImpl.java:320)
	at com.tc.object.tx.ClientTransactionManagerImpl.commit(ClientTransactionManagerImpl.java:313)
	at com.tc.platform.PlatformServiceImpl.unlock(PlatformServiceImpl.java:609)
	at com.tc.platform.PlatformServiceImpl.commitLock(PlatformServiceImpl.java:310)
	at com.tc.platform.rejoin.RejoinAwarePlatformService.commitLock(RejoinAwarePlatformService.java:284)
	at com.terracotta.toolkit.concurrent.locks.ToolkitLockingApi.unlock(ToolkitLockingApi.java:84)
	at com.terracotta.toolkit.concurrent.locks.UnnamedToolkitLock.unlock(UnnamedToolkitLock.java:69)
	at com.terracotta.toolkit.nonstop.NonStopLockImpl.unlock(NonStopLockImpl.java:65)
	at org.terracotta.modules.ehcache.concurrency.TCCacheLockProvider$TCSync.unlock(TCCacheLockProvider.java:90)
	at org.terracotta.modules.ehcache.concurrency.NonStopSyncWrapper.unlock(NonStopSyncWrapper.java:52)
	at org.hibernate.cache.ehcache.internal.regions.EhcacheTransactionalDataRegion.writeUnlock(EhcacheTransactionalDataRegion.java:227)
	at org.hibernate.cache.ehcache.internal.strategy.AbstractReadWriteEhcacheAccessStrategy.putFromLoad(AbstractReadWriteEhcacheAccessStrategy.java:106)
```